### PR TITLE
clusterCreator no longer overwrites an existing name tag.

### DIFF
--- a/src/clusterCreator.coffee
+++ b/src/clusterCreator.coffee
@@ -29,7 +29,7 @@ class ClusterCreator
 		params.Name = @workstationIdentifier.getName()
 		nameTag = _.find(params.Tags, { Key: 'Name' })
 		if not params.Tags then params.Tags = [ ]
-		if nameTag then nameTag.Value = params.Name else params.Tags.push({ Key: 'Name', Value: params.Name })
+		if not nameTag then params.Tags.push({ Key: 'Name', Value: params.Name })
 
 		runJob = @q.nbind(@emr.runJobFlow, @emr)
 		runJob params

--- a/tests/clusterCreator_test.coffee
+++ b/tests/clusterCreator_test.coffee
@@ -137,21 +137,6 @@ describe 'clusterCreator', ->
 						emr.runJobFlowCalls[0].Tags[0].Value.should.equal(wi.getName())
 						done()
 
-		it 'should update the name tag if it does exist', (done) ->
-
-			emr = new emrStub()
-			wi = new workstationIdentifier()
-			extender =
-				extend: ->
-					return { Tags: [ { Key: "Name", Value: "gibberish" } ] }
-
-			cc = new clusterCreator(emr, wi, null, null, extender)
-
-			cc.create()
-				.done =>
-						emr.runJobFlowCalls[0].Tags[0].Value.should.equal(wi.getName())
-						done()
-
 		it 'should pass the command line variables to the template resolver', (done) ->
 
 			emr = new emrStub()

--- a/tests/templateGatherer_test.coffee
+++ b/tests/templateGatherer_test.coffee
@@ -2,6 +2,7 @@
 
 should = require 'should'
 Gatherer = require '../src/templateGatherer'
+path = require 'path'
 
 describe 'TemplateGatherer', ->
 	context 'constructor', ->
@@ -27,8 +28,8 @@ describe 'TemplateGatherer', ->
 					return { isFile: -> return true }
 
 			expected = [
-				'/cwd/one.tommy',
-				'/cwd/two.tommy'
+				path.normalize('/cwd/one.tommy'),
+				path.normalize('/cwd/two.tommy')
 			]
 
 			target = new Gatherer(fs)


### PR DESCRIPTION
This change is to remove the logic that overwrites an existing name tag. When creating EMR clusters that run as a scheduled job through a CI pipeline, I'd like to be able to set the name of the cluster to the name of the job that's running, rather than the hostname_username.
