### PR TITLE
Removed defaults so InstanceGroup can be defined

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,9 @@ For example:  Let's say you wanted to create 4 instances in your cluster instead
 	{
 		Instances: {
 			InstanceCount: <%= count %>
+			...
 		}
+		...
 	}
 
 When you're ready to create the cluster and know you want 10 instances in the group, you would run the following in the working directory of your tommy file/s:

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,9 @@ Creating
 
 Tommy is built on top of the [node AWS SDK](https://aws.amazon.com/sdk-for-node-js/). Creating a cluster from that SDK requires that all options in creating that cluster be defined in a JSON object.  Tommy uses this fact to streamline the creation process by allowing the user to define sepperate templates in the current working directory.  Tommy reads in those templates (tommy files), merges them, applies variables and then presents the final JSON object to the SDK for creation.
 
-By default, Tommy uses the following template which all other provided templates are merged against.
+If a user provides any templates (tommy files), then only those templates will be used to create the final JSON output to present to the SDK. 
+
+However, if no templates are provided by the user, then Tommy uses the following template by default:
 
 	{
 	  Instances: {

--- a/src/createParameters.js
+++ b/src/createParameters.js
@@ -4,7 +4,10 @@
 module.exports = {
   Instances: {
     HadoopVersion: '2.7.1',
-    KeepJobFlowAliveWhenNoSteps: true
+    InstanceCount: 3,
+    KeepJobFlowAliveWhenNoSteps: true,
+    MasterInstanceType: 'm1.small',
+    SlaveInstanceType: 'm1.small'
   },
   JobFlowRole: "EMR_EC2_DefaultRole",
   ServiceRole: "EMR_DefaultRole",

--- a/src/createParameters.js
+++ b/src/createParameters.js
@@ -4,10 +4,7 @@
 module.exports = {
   Instances: {
     HadoopVersion: '2.7.1',
-    InstanceCount: 3,
-    KeepJobFlowAliveWhenNoSteps: true,
-    MasterInstanceType: 'm1.small',
-    SlaveInstanceType: 'm1.small'
+    KeepJobFlowAliveWhenNoSteps: true
   },
   JobFlowRole: "EMR_EC2_DefaultRole",
   ServiceRole: "EMR_DefaultRole",

--- a/src/extender.coffee
+++ b/src/extender.coffee
@@ -14,7 +14,8 @@ class Extender
 			if not check.object(item)
 				throw Error('You must supply an array of objects as sources.')
 
-		sources.splice(0, 0, @params)
+		if not sources.length
+			sources.splice(0, 0, @params)
 		
 		merge = _.spread(_.merge)
 		return merge(sources)

--- a/tests/extender_test.coffee
+++ b/tests/extender_test.coffee
@@ -32,7 +32,7 @@ describe 'Extender', ->
 				target = new Extender()
 				target.extend("hello")
 
-		it 'should merge object with the default object', ->
+		it 'should not merge non-empty object with the default object', ->
 
 			params =
 				a: true
@@ -50,9 +50,27 @@ describe 'Extender', ->
 			expected =
 				a: false
 				b:
-					c: false
 					d: 1
 				h: "hello"
+
+			target = new Extender(null, params)
+			should.deepEqual(target.extend([source0, source1]), expected)
+
+		it 'should merge empty object with the default object', ->
+
+			params =
+				a: true
+				b:
+					c: false
+
+			source0 =
+
+			source1 =
+
+			expected =
+				a: true
+				b:
+					c: false
 
 			target = new Extender(null, params)
 			should.deepEqual(target.extend([source0, source1]), expected)


### PR DESCRIPTION
AWS runJobFlow lets you use one of three options when defining your instances:
1) InstanceCount + MasterInstanceType + SlaveInstanceType
2) InstanceFleets
3) InstanceGroups

Only InstanceGroups/InstanceFleets allow you to specify volume information for your instances.  In order to define an InstanceGroup or InstanceFleets the defaults Tommy provides for InstanceCount/MasterInstanceType/SlaveInstanceType need to be removed to avoid the error of trying to use more than 1 of the methods above to define instances.